### PR TITLE
Update node version in github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,9 @@ jobs:
           version: 4.0.19
           actions-cache-folder: ".emsdk-cache"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22.16.0"
+          node-version: "24.13.1"
           registry-url: "https://registry.npmjs.org"
       - name: Install yarn package manager
         run: npm install --global yarn

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -43,9 +43,6 @@ jobs:
         run: |
           yarn run clean
           yarn run build
-      - name: Perform npm package publish dry run
-        run: |
-          npm publish . --dry-run
   macos:
     name: Build and run tests on macOS
     runs-on: ${{ matrix.os }}
@@ -91,5 +88,3 @@ jobs:
         run: |
           yarn run clean
           yarn run build
-      - name: Perform npm package publish dry run
-        run: npm publish . --dry-run

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -23,9 +23,9 @@ jobs:
           version: 4.0.19
           actions-cache-folder: ".emsdk-cache"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22.16.0"
+          node-version: "24.13.1"
       - name: Install yarn package manager
         run: npm install --global yarn
       - name: Install dependencies
@@ -64,9 +64,9 @@ jobs:
           version: 4.0.19
           actions-cache-folder: ".emsdk-cache"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22.16.0"
+          node-version: "24.13.1"
       - name: Install yarn package manager
         run: npm install --global yarn
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imagingdatacommons/dicomicc",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "WASM bindings and JavaScript API for the dicomicc C library",
   "main": "dist/dicomiccwasm.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/imagingdatacommons/libdicomicc.git"
+    "url": "git+https://github.com/imagingdatacommons/libdicomicc.git"
   },
   "keywords": [
     "ICC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imagingdatacommons/dicomicc",
-  "version": "0.2.4",
+  "version": "0.2.3",
 
   "description": "WASM bindings and JavaScript API for the dicomicc C library",
   "main": "dist/dicomiccwasm.js",


### PR DESCRIPTION
I have updated the node version in the github action scripts to the latest active LTS version (24.13.1). This comes with a newer npm version, which allows us to use the open id infrastructure when publishing to npm.

While doing this, I've also
1) Fixed the npm package url (we had to add `git+` in front)
2) Bumped the package to version 0.2.4 (dry run whines about this and apperently, 0.2.3 is already published)